### PR TITLE
fix: sanitize credential paths from yt-dlp stderr before logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ __pycache__/
 node_modules/
 !.envrc
 .serena/
+.worktrees
+.config/temp.opencode*

--- a/src/webfetch-handlers/domains/youtube.ts
+++ b/src/webfetch-handlers/domains/youtube.ts
@@ -86,6 +86,18 @@ async function pickTranscriptFile(tempDir: string): Promise<string | undefined> 
   return `${tempDir}/${first}`;
 }
 
+function sanitizeStderr(stderr: string): string {
+  let clean = stderr;
+  const cookiesFile = (process.env.YTDLP_COOKIES_FILE ?? "").trim();
+  if (cookiesFile) {
+    clean = clean.replaceAll(cookiesFile, "[REDACTED_COOKIES_PATH]");
+  }
+  // Redact any absolute paths that look like config/credential files
+  const sensitivePathRegex = /(?:^|\s)(\/(?:[\w.-]+\/)*[\w.-]*(?:cookie|config|cred|secret|auth|netrc|token|key)[\w.-]*)(?:\s|$)/gi;
+  clean = clean.replaceAll(sensitivePathRegex, " [REDACTED_PATH] ");
+  return clean.trim();
+}
+
 export async function fetchYoutubeTranscriptMarkdown(input: {
   url: URL;
   runCommand: RunCommand;
@@ -102,7 +114,7 @@ export async function fetchYoutubeTranscriptMarkdown(input: {
           "# YouTube Transcript",
           "",
           "Transcript extraction failed at subtitle discovery.",
-          `Reason: ${listSubs.stderrText.trim() || `yt-dlp exited ${listSubs.exitCode}`}`,
+          `Reason: ${sanitizeStderr(listSubs.stderrText) || `yt-dlp exited ${listSubs.exitCode}`}`,
           "",
           "Pipeline requirements:",
           "- yt-dlp with curl-cffi impersonation support.",
@@ -165,7 +177,7 @@ export async function fetchYoutubeTranscriptMarkdown(input: {
           "# YouTube Transcript",
           "",
           "Transcript extraction failed at audio download stage.",
-          `Reason: ${audioDownload.stderrText.trim() || `yt-dlp exited ${audioDownload.exitCode}`}`,
+          `Reason: ${sanitizeStderr(audioDownload.stderrText) || `yt-dlp exited ${audioDownload.exitCode}`}`,
           "",
           "Check that YouTube access is available from this environment and bot-check/cookies requirements are satisfied.",
         ].join("\n"),
@@ -212,7 +224,7 @@ export async function fetchYoutubeTranscriptMarkdown(input: {
           "# YouTube Transcript",
           "",
           "Whisper transcription stage failed.",
-          `Reason: ${whisper.stderrText.trim() || `whisper exited ${whisper.exitCode}`}`,
+          `Reason: ${sanitizeStderr(whisper.stderrText) || `whisper exited ${whisper.exitCode}`}`,
         ].join("\n"),
       };
     }

--- a/tests/unit/webfetch-handlers/youtube-sanitization.test.ts
+++ b/tests/unit/webfetch-handlers/youtube-sanitization.test.ts
@@ -1,0 +1,22 @@
+import { fetchYoutubeTranscriptMarkdown } from "../../../src/webfetch-handlers/domains/youtube.ts";
+import { expect, test } from "bun:test";
+
+test("sanitize stderr strips YTDLP_COOKIES_FILE and sensitive paths", async () => {
+    process.env.YTDLP_COOKIES_FILE = "/home/user/my_secret_cookies.txt";
+
+    const output = await fetchYoutubeTranscriptMarkdown({
+        url: new URL("https://www.youtube.com/watch?v=dQw4w9WgXcQ"),
+        runCommand: async () => ({
+            stdoutText: "",
+            stderrText: "Error! /home/user/my_secret_cookies.txt not found. Also checked /etc/config.json and /var/www/secret/auth.json.",
+            exitCode: 1,
+        }),
+    });
+
+    expect(output.content).toContain("[REDACTED_COOKIES_PATH]");
+    expect(output.content).toContain("[REDACTED_PATH]");
+    expect(output.content).not.toContain("/home/user/my_secret_cookies.txt");
+    expect(output.content).not.toContain("/etc/config.json");
+    expect(output.content).not.toContain("/var/www/secret/auth.json");
+    expect(output.content).not.toContain("secret");
+});


### PR DESCRIPTION
## Summary

- Adds a `sanitizeStderr()` function in `youtube.ts` that redacts the `YTDLP_COOKIES_FILE` path and any other absolute paths matching common credential/config file patterns (cookie, config, cred, secret, auth, netrc, token, key) before they appear in error output returned to the LLM
- Replaces all three raw `stderrText.trim()` usages in `fetchYoutubeTranscriptMarkdown` with `sanitizeStderr()` calls
- Adds a unit test confirming both the env-var-based and regex-based redaction paths work correctly

## Test plan

- [ ] Run `bun test tests/unit/webfetch-handlers/youtube-sanitization.test.ts` — should pass
- [ ] Confirm no credential paths appear in error output when `YTDLP_COOKIES_FILE` is set
- [ ] Confirm paths matching sensitive-file patterns are replaced with `[REDACTED_PATH]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)